### PR TITLE
Fix sensor data and update documentation for V5 devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Hughes Power Watchdog devices come in two generations, each using a different BL
 | Generation | Connectivity | Model Suffix | BLE Device Name | Mobile App | Example Models |
 |-----------|-------------|-------------|----------------|-----------|---------------|
 | **Gen 1** | Bluetooth only | EPO | `PMD*`, `PWS*`, `PMS*` | [Power Watchdog Bluetooth ONLY](https://play.google.com/store/apps/details?id=com.hughes.epo) | PWD30-EPO, PWD50-EPO, PWD50-EPD |
-| **Gen 2** | WiFi + Bluetooth | EPOW | `WD_V5_*` | [Power Watchdog WiFi](https://play.google.com/store/apps/details?id=com.yw.watchdog) | PWD30EPOW, PWD50-EPOW |
+| **Gen 2** | WiFi + Bluetooth | EPOW | `WD_V5_*`, `WD_E5_*` | [Power Watchdog WiFi](https://play.google.com/store/apps/details?id=com.yw.watchdog) | PWD30EPOW, PWD50-EPOW |
 
 Both generations are portable or hardwired (-H suffix). This integration uses only the BLE connection, even on Gen 2 WiFi models.
 
@@ -26,6 +26,7 @@ Both generations are portable or hardwired (-H suffix). This integration uses on
 | PWD50-EPD | Gen 1 | Legacy | None |
 | PWD-VM-30A | Gen 1 | Legacy | None |
 | PWD30EPOW | Gen 2 | V5 | None |
+| PWD50EPOW | Gen 2 | V5 | None |
 
 Please let me know via [GitHub issues](https://github.com/john-k-mcdowell/My-Hughes-Power-Watchdog/issues) if you have tested on other models so they can be included in the README.
 
@@ -37,13 +38,13 @@ Based on the ESPHome implementation by spbrogan, tango2590, and makifoxgirl.
 
 ### Supported Models
 - **Gen 1** - Hughes Power Watchdog (PMD/PWS/PMS) - Bluetooth only models
-- **Gen 2** - Hughes Power Watchdog (WD_V5) - WiFi + Bluetooth models (v0.5.0+)
+- **Gen 2** - Hughes Power Watchdog (WD_V5/WD_E5) - WiFi + Bluetooth models (v0.5.0+)
 
 ### Real-Time Sensor Updates (v0.6.0)
 
 Starting with v0.6.0, the integration uses a **push-based model** for real-time sensor updates. The device streams data continuously via BLE notifications (~1 second intervals), and the integration subscribes once and pushes updates to Home Assistant entities as they arrive. This replaces the previous polling model that only captured data every 30 seconds.
 
-> **Note:** The real-time push model has been tested and verified on Gen 1 devices. The same approach has been applied to Gen 2 devices but **has not yet been tested** due to lack of a Gen 2 test device. If you have a Gen 2 (EPOW/WD_V5) device, please enable debug logging and report any issues via [GitHub issues](https://github.com/john-k-mcdowell/My-Hughes-Power-Watchdog/issues).
+> **Note:** The real-time push model has been validated on both Gen 1 and Gen 2 devices. If you encounter issues with a specific model, please enable debug logging and report any issues via [GitHub issues](https://github.com/john-k-mcdowell/My-Hughes-Power-Watchdog/issues).
 
 ### Available Sensors
 - **Line 1 Voltage** (volts)
@@ -106,14 +107,14 @@ If your device is not auto-discovered but is powered on and within Bluetooth ran
 
 ## Gen 2 (V5) Protocol Support
 
-Starting with v0.5.0, this integration supports Gen 2 devices (WiFi + Bluetooth models with device names starting with `WD_V5_`, such as PWD30EPOW). These devices use a different BLE protocol than the Gen 1 Bluetooth-only models. The protocol header `$yw@` corresponds to the "yw" identifier used in the official [Power Watchdog WiFi](https://play.google.com/store/apps/details?id=com.yw.watchdog) app.
+Starting with v0.5.0, this integration supports Gen 2 devices (WiFi + Bluetooth models with device names starting with `WD_V5_` or `WD_E5_`, such as PWD30EPOW/PWD50EPOW). These devices use a different BLE protocol than the Gen 1 Bluetooth-only models. The protocol header `$yw@` corresponds to the "yw" identifier used in the official [Power Watchdog WiFi](https://play.google.com/store/apps/details?id=com.yw.watchdog) app.
 
 **Gen 2 (V5) Status:**
 - Voltage, Current, Power readings - Working
 - Energy (kWh) - Working
-- Real-time push updates (v0.6.0) - **Not yet tested** (needs Gen 2 device)
+- Real-time push updates (v0.6.0) - Working
 - Error codes - Not yet implemented
-- Line 2 (50A dual-phase) - Not yet tested
+- Line 2 (50A dual-phase) - Working
 
 **If you have a Gen 2 device**, please help us by:
 1. Enabling debug logging (see below)

--- a/custom_components/hughes_power_watchdog/const.py
+++ b/custom_components/hughes_power_watchdog/const.py
@@ -13,10 +13,10 @@ CONF_MAC_ADDRESS = "mac_address"
 
 # Device name prefixes that we look for
 # Legacy devices: PMD, PWS, PMS (use old protocol)
-# Modern V5 devices: WD_V5 (use new protocol)
-DEVICE_NAME_PREFIXES = ["PMD", "PWS", "PMS", "WD_V5"]
+# Modern V5 devices: WD_V5 / WD_E5 (use new protocol)
+DEVICE_NAME_PREFIXES = ["PMD", "PWS", "PMS", "WD_V5", "WD_E5"]
 DEVICE_NAME_PREFIXES_LEGACY = ["PMD", "PWS", "PMS"]
-DEVICE_NAME_PREFIXES_MODERN_V5 = ["WD_V5"]
+DEVICE_NAME_PREFIXES_MODERN_V5 = ["WD_V5", "WD_E5"]
 
 # Connection health check interval (coordinator watchdog, not data polling)
 # Actual data arrives via push notifications from the device (~1s intervals)
@@ -44,7 +44,7 @@ CHARACTERISTIC_UUID_TX = LEGACY_CHARACTERISTIC_UUID_TX
 CHARACTERISTIC_UUID_RX = LEGACY_CHARACTERISTIC_UUID_RX
 
 # =============================================================================
-# MODERN V5 PROTOCOL (WD_V5_* devices)
+# MODERN V5 PROTOCOL (WD_V5_* / WD_E5_* devices)
 # =============================================================================
 # Reverse engineered from Bluetooth captures - see docs/protocol.md
 MODERN_V5_SERVICE_UUID = "000000ff-0000-1000-8000-00805f9b34fb"

--- a/custom_components/hughes_power_watchdog/coordinator.py
+++ b/custom_components/hughes_power_watchdog/coordinator.py
@@ -920,7 +920,7 @@ class HughesPowerWatchdogCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "power": power,
                     "energy": 0,
                 }
-                _LOGGER.info(
+                _LOGGER.debug(
                     "[%s] modern_V5: Line 2 packet - V=%.2fV I=%.2fA P=%.2fW (line-id mode)",
                     self.device_name,
                     voltage,
@@ -935,7 +935,7 @@ class HughesPowerWatchdogCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "energy": energy,
                 }
                 if is_line_1_packet:
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "[%s] modern_V5: Line 1 packet - V=%.2fV I=%.2fA P=%.2fW E=%.2fkWh (line-id mode)",
                         self.device_name,
                         voltage,
@@ -944,7 +944,7 @@ class HughesPowerWatchdogCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         energy,
                     )
                 else:
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "[%s] modern_V5: Line 1 - V=%.2fV I=%.2fA P=%.2fW E=%.2fkWh",
                         self.device_name,
                         voltage,
@@ -960,7 +960,7 @@ class HughesPowerWatchdogCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 embedded_line_2 = self._decode_modern_v5_embedded_line2(data)
             if embedded_line_2:
                 self._line_2_data = embedded_line_2
-                _LOGGER.info(
+                _LOGGER.debug(
                     "[%s] modern_V5: Line 2 - V=%.2fV I=%.2fA P=%.2fW (decoded block)",
                     self.device_name,
                     embedded_line_2["voltage"],

--- a/custom_components/hughes_power_watchdog/coordinator.py
+++ b/custom_components/hughes_power_watchdog/coordinator.py
@@ -66,7 +66,6 @@ from .const import (
     MODERN_V5_MIN_ENERGY_PACKET_SIZE,
     MODERN_V5_MIN_L2_PACKET_SIZE,
     MODERN_V5_MSG_TYPE_DATA,
-    MODERN_V5_VOLTAGE_MAX,
     MODERN_V5_VOLTAGE_MIN,
     # Legacy protocol UUIDs
     LEGACY_SERVICE_UUID,
@@ -145,7 +144,7 @@ class HughesPowerWatchdogCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Data buffers
         self._data_buffer: bytearray = bytearray()
         self._line_1_data: dict[str, float] = {}
-        self._line_2_data: dict[str, float] = {}
+        self._line_2_data: dict[str, float] | None = None
         self._error_code: int = 0
 
         # Modern V5 specific: track if initialization command has been sent
@@ -908,61 +907,66 @@ class HughesPowerWatchdogCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 power_raw,
             )
 
-            _LOGGER.info(
-                "[%s] modern_V5: Line 1 - V=%.2fV I=%.2fA P=%.2fW E=%.2fkWh",
-                self.device_name,
-                voltage,
-                current,
-                power,
-                energy,
-            )
+            # Some 50A V5 devices may send line-specific packets reusing the
+            # primary V/I/P offsets, with a legacy-style line identifier.
+            packet_line_id = bytes(data[37:40]) if len(data) >= 40 else None
+            is_line_2_packet = packet_line_id == LINE_2_ID
+            is_line_1_packet = packet_line_id == LINE_1_ID
 
-            # Store Line 1 data
-            self._line_1_data = {
-                "voltage": voltage,
-                "current": current,
-                "power": power,
-                "energy": energy,
-            }
-
-            # Try to decode Line 2 if packet is long enough
-            # For dual-phase V5 devices (if they exist), L2 data should be at bytes 25-36
-            self._line_2_data = None
-            if len(data) >= MODERN_V5_MIN_L2_PACKET_SIZE:
-                l2_voltage_bytes = data[MODERN_V5_BYTE_L2_VOLTAGE_START:MODERN_V5_BYTE_L2_VOLTAGE_END]
-                l2_voltage_raw = struct.unpack(">I", l2_voltage_bytes)[0]
-                l2_voltage = l2_voltage_raw / DATA_CONVERSION_FACTOR
-
-                # Check if L2 voltage is in valid range (indicates dual-phase device)
-                if MODERN_V5_VOLTAGE_MIN <= l2_voltage <= MODERN_V5_VOLTAGE_MAX:
-                    l2_current_bytes = data[MODERN_V5_BYTE_L2_CURRENT_START:MODERN_V5_BYTE_L2_CURRENT_END]
-                    l2_current_raw = struct.unpack(">I", l2_current_bytes)[0]
-                    l2_current = l2_current_raw / DATA_CONVERSION_FACTOR
-
-                    l2_power_bytes = data[MODERN_V5_BYTE_L2_POWER_START:MODERN_V5_BYTE_L2_POWER_END]
-                    l2_power_raw = struct.unpack(">I", l2_power_bytes)[0]
-                    l2_power = l2_power_raw / DATA_CONVERSION_FACTOR
-
-                    self._line_2_data = {
-                        "voltage": l2_voltage,
-                        "current": l2_current,
-                        "power": l2_power,
-                        "energy": 0,  # L2 energy position unknown
-                    }
-
+            if is_line_2_packet:
+                self._line_2_data = {
+                    "voltage": voltage,
+                    "current": current,
+                    "power": power,
+                    "energy": 0,
+                }
+                _LOGGER.info(
+                    "[%s] modern_V5: Line 2 packet - V=%.2fV I=%.2fA P=%.2fW (line-id mode)",
+                    self.device_name,
+                    voltage,
+                    current,
+                    power,
+                )
+            else:
+                self._line_1_data = {
+                    "voltage": voltage,
+                    "current": current,
+                    "power": power,
+                    "energy": energy,
+                }
+                if is_line_1_packet:
                     _LOGGER.info(
-                        "[%s] modern_V5: Line 2 - V=%.2fV I=%.2fA P=%.2fW (dual-phase detected)",
+                        "[%s] modern_V5: Line 1 packet - V=%.2fV I=%.2fA P=%.2fW E=%.2fkWh (line-id mode)",
                         self.device_name,
-                        l2_voltage,
-                        l2_current,
-                        l2_power,
+                        voltage,
+                        current,
+                        power,
+                        energy,
                     )
                 else:
-                    _LOGGER.debug(
-                        "[%s] modern_V5: L2 voltage %.2fV out of range, single-phase device",
+                    _LOGGER.info(
+                        "[%s] modern_V5: Line 1 - V=%.2fV I=%.2fA P=%.2fW E=%.2fkWh",
                         self.device_name,
-                        l2_voltage,
+                        voltage,
+                        current,
+                        power,
+                        energy,
                     )
+
+            # Try to decode embedded Line 2 block (bytes 25-36). This supports
+            # devices that report both lines in one frame.
+            embedded_line_2 = self._decode_modern_v5_dual_block_line2(data)
+            if not embedded_line_2:
+                embedded_line_2 = self._decode_modern_v5_embedded_line2(data)
+            if embedded_line_2:
+                self._line_2_data = embedded_line_2
+                _LOGGER.info(
+                    "[%s] modern_V5: Line 2 - V=%.2fV I=%.2fA P=%.2fW (decoded block)",
+                    self.device_name,
+                    embedded_line_2["voltage"],
+                    embedded_line_2["current"],
+                    embedded_line_2["power"],
+                )
 
             # Error code not yet decoded for V5
             self._error_code = 0
@@ -983,6 +987,115 @@ class HughesPowerWatchdogCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 err,
                 data.hex(),
             )
+
+    def _decode_modern_v5_dual_block_line2(
+        self, data: bytes | bytearray
+    ) -> dict[str, float] | None:
+        """Decode Line 2 for 79-byte V5 packets with dual 34-byte data blocks.
+
+        Observed on Gen 2 50A devices:
+        - Block 1 starts at byte 9 (Line 1 V/I/P/E)
+        - Block 2 starts at byte 43 (Line 2 V/I/P/E)
+        """
+        # Needs bytes up through 54 for L2 V/I/P extraction.
+        if len(data) < 55:
+            return None
+
+        # Byte 7-8 appears to be payload length. 0x0044 (68) indicates two
+        # 34-byte blocks in the payload, as seen in Gen 2 50A captures.
+        if data[7:9] != b"\x00\x44":
+            return None
+
+        l2_voltage_bytes = data[43:47]
+        l2_current_bytes = data[47:51]
+        l2_power_bytes = data[51:55]
+
+        l2_voltage = struct.unpack(">I", l2_voltage_bytes)[0] / DATA_CONVERSION_FACTOR
+        l2_current = struct.unpack(">I", l2_current_bytes)[0] / DATA_CONVERSION_FACTOR
+        l2_power = struct.unpack(">I", l2_power_bytes)[0] / DATA_CONVERSION_FACTOR
+
+        if not (MODERN_V5_VOLTAGE_MIN <= l2_voltage <= 145.0):
+            return None
+        if not (0.0 <= l2_current <= 80.0):
+            return None
+        if not (0.0 <= l2_power <= 20000.0):
+            return None
+
+        _LOGGER.debug(
+            "[%s] modern_V5: Dual-block L2 raw V=%s I=%s P=%s",
+            self.device_name,
+            l2_voltage_bytes.hex(),
+            l2_current_bytes.hex(),
+            l2_power_bytes.hex(),
+        )
+
+        return {
+            "voltage": l2_voltage,
+            "current": l2_current,
+            "power": l2_power,
+            "energy": 0,
+        }
+
+    def _decode_modern_v5_embedded_line2(self, data: bytes | bytearray) -> dict[str, float] | None:
+        """Decode Line 2 from bytes 25-36 in V5 packets using robust fallbacks."""
+        if len(data) < MODERN_V5_MIN_L2_PACKET_SIZE:
+            return None
+
+        l2_voltage_bytes = data[MODERN_V5_BYTE_L2_VOLTAGE_START:MODERN_V5_BYTE_L2_VOLTAGE_END]
+        l2_current_bytes = data[MODERN_V5_BYTE_L2_CURRENT_START:MODERN_V5_BYTE_L2_CURRENT_END]
+        l2_power_bytes = data[MODERN_V5_BYTE_L2_POWER_START:MODERN_V5_BYTE_L2_POWER_END]
+
+        # Try the known format first, then common fallback encodings.
+        # Scale=100 is included because some vendor payloads use centi-units.
+        decode_attempts = (
+            ("be_10000", "big", DATA_CONVERSION_FACTOR),
+            ("le_10000", "little", DATA_CONVERSION_FACTOR),
+            ("be_100", "big", 100),
+            ("le_100", "little", 100),
+        )
+
+        best_result: dict[str, float] | None = None
+        best_error = float("inf")
+
+        for mode, byteorder, scale in decode_attempts:
+            voltage = int.from_bytes(l2_voltage_bytes, byteorder=byteorder, signed=False) / scale
+            current = int.from_bytes(l2_current_bytes, byteorder=byteorder, signed=False) / scale
+            power = int.from_bytes(l2_power_bytes, byteorder=byteorder, signed=False) / scale
+
+            # Plausibility checks for RV shore power.
+            if not (MODERN_V5_VOLTAGE_MIN <= voltage <= 260.0):
+                continue
+            if not (0.0 <= current <= 70.0):
+                continue
+            if not (0.0 <= power <= 15000.0):
+                continue
+
+            # Prefer candidates where real power is reasonably close to
+            # apparent power, while allowing PF variation and measurement noise.
+            apparent_power = voltage * current
+            max_reasonable_power = (apparent_power * 1.25) + 250.0
+            if power > max_reasonable_power:
+                continue
+
+            error = abs(apparent_power - power)
+            if best_result is None or error < best_error:
+                best_error = error
+                best_result = {
+                    "voltage": voltage,
+                    "current": current,
+                    "power": power,
+                    "energy": 0,
+                }
+                _LOGGER.debug(
+                    "[%s] modern_V5: Embedded L2 candidate %s accepted V=%.2f I=%.2f P=%.2f",
+                    self.device_name,
+                    mode,
+                    voltage,
+                    current,
+                    power,
+                )
+
+        return best_result
 
     def _build_data_dict(self) -> dict[str, Any]:
         """Build data dictionary for entities."""

--- a/custom_components/hughes_power_watchdog/manifest.json
+++ b/custom_components/hughes_power_watchdog/manifest.json
@@ -21,6 +21,9 @@
     },
     {
       "local_name": "WD_V5*"
+    },
+    {
+      "local_name": "WD_E5*"
     }
   ]
 }

--- a/custom_components/hughes_power_watchdog/manifest.json
+++ b/custom_components/hughes_power_watchdog/manifest.json
@@ -1,14 +1,18 @@
 {
   "domain": "hughes_power_watchdog",
   "name": "Hughes Power Watchdog",
-  "codeowners": ["@john-k-mcdowell"],
+  "codeowners": [
+    "@john-k-mcdowell"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/john-k-mcdowell/My-Hughes-Power-Watchdog",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/john-k-mcdowell/My-Hughes-Power-Watchdog/issues",
-  "requirements": ["bleak-retry-connector>=3.5.0"],
-  "version": "0.6.0",
+  "requirements": [
+    "bleak-retry-connector>=3.5.0"
+  ],
+  "version": "0.6.1",
   "bluetooth": [
     {
       "local_name": "PMD*"

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -10,15 +10,15 @@ This document describes the two Bluetooth Low Energy (BLE) protocols used by Hug
 | Generation | Connectivity | Model Suffix | BLE Device Name | Mobile App |
 |-----------|-------------|-------------|----------------|-----------|
 | **Gen 1** | Bluetooth only | EPO | `PMD*`, `PWS*`, `PMS*` | [Power Watchdog Bluetooth ONLY](https://play.google.com/store/apps/details?id=com.hughes.epo) |
-| **Gen 2** | WiFi + Bluetooth | EPOW | `WD_V5_*` | [Power Watchdog WiFi](https://play.google.com/store/apps/details?id=com.yw.watchdog) |
+| **Gen 2** | WiFi + Bluetooth | EPOW | `WD_V5_*`, `WD_E5_*` | [Power Watchdog WiFi](https://play.google.com/store/apps/details?id=com.yw.watchdog) |
 
 The V5 protocol header `$yw@` corresponds to the `com.yw.watchdog` package name of the official Gen 2 WiFi app.
 
 ## Protocol Overview
 
-| Feature | Gen 1 Legacy (PMD/PWS/PMS) | Gen 2 V5 (WD_V5) |
+| Feature | Gen 1 Legacy (PMD/PWS/PMS) | Gen 2 V5 (WD_V5/WD_E5) |
 |---------|---------------------------|-------------------|
-| Device Names | `PMD*`, `PWS*`, `PMS*` | `WD_V5_*` |
+| Device Names | `PMD*`, `PWS*`, `PMS*` | `WD_V5_*`, `WD_E5_*` |
 | Service UUID | `0000ffe0-0000-1000-8000-00805f9b34fb` | `000000ff-0000-1000-8000-00805f9b34fb` |
 | TX Characteristic | `0000ffe2-0000-1000-8000-00805f9b34fb` | `0000ff01-0000-1000-8000-00805f9b34fb` |
 | RX Characteristic | `0000fff5-0000-1000-8000-00805f9b34fb` | Same as TX (bidirectional) |
@@ -140,7 +140,7 @@ def decode_legacy_packet(data: bytes) -> dict:
 
 ---
 
-## Gen 2 V5 Protocol (WD_V5)
+## Gen 2 V5 Protocol (WD_V5 / WD_E5)
 
 Used by Gen 2 WiFi + Bluetooth devices (EPOW models). Reverse engineered from Bluetooth HCI captures of a WD_V5 device (device name: `WD_V5_9e9e6e20b9ed`).
 
@@ -180,11 +180,18 @@ Three message types have been observed:
 
 | Type | Value | Description |
 |------|-------|-------------|
-| Data | `0x01` | Power measurement data (45 bytes) |
+| Data | `0x01` | Power measurement data (45 or 79 bytes observed) |
 | Status | `0x02` | Status/info packet (24-27 bytes) |
 | Control | `0x06` | Protocol handshake/acknowledgment |
 
-### Data Packet Structure (Type 0x01, 45 bytes)
+### Data Packet Structure (Type 0x01)
+
+Two payload layouts have been observed:
+
+- **Single-block layout** (`bytes 7-8 = 0x0022`, 45-byte packet)
+- **Dual-block layout** (`bytes 7-8 = 0x0044`, 79-byte packet, used by tested Gen 2 50A devices)
+
+#### Single-Block Layout (45 bytes)
 
 | Offset | Size | Field | Format | Status |
 |--------|------|-------|--------|--------|
@@ -204,13 +211,33 @@ Three message types have been observed:
 | 41-42 | 2 | Error code? | 0 in all captures | Unconfirmed |
 | 43-44 | 2 | End Marker | ASCII `q!` | Decoded |
 
-### Line 2 Detection (Speculative)
+#### Dual-Block Layout (79 bytes, validated on Gen 2 50A)
+
+| Offset | Size | Field | Format | Status |
+|--------|------|-------|--------|--------|
+| 0-3 | 4 | Header | ASCII `$yw@` | Decoded |
+| 4 | 1 | Unknown | Always `0x01` | Unknown |
+| 5 | 1 | Sequence | Incrementing counter | Decoded |
+| 6 | 1 | Message Type | `0x01` = data | Decoded |
+| 7-8 | 2 | Length | `0x0044` (68) | Decoded |
+| **9-12** | 4 | **Voltage (L1)** | BE uint32 / 10000 | **Decoded** |
+| **13-16** | 4 | **Current (L1)** | BE uint32 / 10000 | **Decoded** |
+| **17-20** | 4 | **Power (L1)** | BE uint32 / 10000 | **Decoded** |
+| **21-24** | 4 | **Energy (L1)** | BE uint32 / 10000 | **Decoded** |
+| 25-42 | 18 | Unknown per-block fields | Vendor-specific | Partial |
+| **43-46** | 4 | **Voltage (L2)** | BE uint32 / 10000 | **Decoded** |
+| **47-50** | 4 | **Current (L2)** | BE uint32 / 10000 | **Decoded** |
+| **51-54** | 4 | **Power (L2)** | BE uint32 / 10000 | **Decoded** |
+| 55-76 | 22 | Unknown / per-block trailing fields | Vendor-specific | Partial |
+| 77-78 | 2 | End Marker | ASCII `q!` | Decoded |
+
+### Line 2 Detection
 
 For single-phase (30A) devices, only Line 1 data is valid. Bytes 25-36 contain non-voltage values for these devices.
 
-For potential dual-phase (50A) Gen 2 devices, bytes 25-36 are assumed to follow the same format as Line 1. The integration detects dual-phase by checking if the decoded L2 voltage (bytes 25-28) falls within a valid range (90-145V). If it does, L2 current and power are also decoded from bytes 29-36.
+For validated Gen 2 50A dual-phase devices using the 79-byte dual-block layout (`0x0044`), Line 2 is decoded from bytes 43-54.
 
-This approach has **not yet been validated** against an actual dual-phase Gen 2 device.
+For other V5 layouts, the integration still includes fallback decoding for bytes 25-36 when those values are plausible.
 
 ### Status Packet (Type 0x02, 24-27 bytes)
 
@@ -300,9 +327,9 @@ def decode_v5_packet(data: bytes) -> dict:
 | Item | Notes |
 |------|-------|
 | Byte 4 | Always `0x01` - purpose unknown |
-| Bytes 7-8 | Always `0x0022` (34) - purpose unknown (packet length field?) |
+| Bytes 7-8 | Packet length field (`0x0022` single-block, `0x0044` dual-block observed) |
 | Bytes 25-36 on single-phase devices | Values present but not voltage/current/power for these devices |
-| Bytes 25-36 on dual-phase devices | **Speculative** - assumed to be L2 V/I/P but no dual-phase Gen 2 device has been tested |
+| Bytes 25-36 on dual-phase devices | Used as fallback only; primary validated L2 offsets for tested 50A devices are 43-54 in dual-block packets |
 | Bytes 37-40 | Value ~6000, likely frequency (60.00 Hz) but unconfirmed |
 | Bytes 41-42 | Value 0 in all captures, likely error code but mapping unknown |
 | Error code mapping | Gen 2 may use the same codes as Gen 1 (0-7) or different codes |
@@ -313,7 +340,6 @@ def decode_v5_packet(data: bytes) -> dict:
 
 ### Testing Needed
 
-- **Dual-phase Gen 2 device**: Need captures from a 50A Gen 2 device to validate L2 byte positions
 - **Gen 2 error states**: Need captures during fault conditions to decode error fields
 - **Gen 2 frequency**: Need confirmation that bytes 37-40 represent AC frequency
 - **New device models**: Any future Hughes models may use either protocol or introduce a new one
@@ -328,7 +354,7 @@ The integration detects which protocol to use through two mechanisms:
 
 At startup, the device name from the BLE advertisement is checked:
 - Starts with `PMD`, `PWS`, or `PMS` -> Gen 1 Legacy protocol
-- Starts with `WD_V5` -> Gen 2 V5 protocol
+- Starts with `WD_V5` or `WD_E5` -> Gen 2 V5 protocol
 
 ### 2. Service-Based Detection (Confirmation)
 


### PR DESCRIPTION
- Enhance support for V5 devices by fixing missing sensor data.
- Add a new device prefix (E5).
- Update the README to reflect changes in device naming conventions and testing notes.
- Adjust logging levels to reduce noise when not debugging.

My Gen 2 50A device has a Bluetooth name of WD_E5_xxxxx, so I added the E5 prefix. 

I also bumped the version number to 0.6.1. 

Please make sure these changes don't cause any issues with the Gen 1 devices. I don't own a Gen 1 device to test with. 

Thank you so much for all your work on this project!